### PR TITLE
fix compilation when plugin with source in placed inside engine

### DIFF
--- a/Source/PrefabricatorRuntime/Public/Prefab/PrefabActor.h
+++ b/Source/PrefabricatorRuntime/Public/Prefab/PrefabActor.h
@@ -10,7 +10,7 @@ UCLASS(Blueprintable, ConversionRoot, ComponentWrapperClass)
 class PREFABRICATORRUNTIME_API APrefabActor : public AActor {
 	GENERATED_UCLASS_BODY()
 public:
-	UPROPERTY(BlueprintReadOnly, meta = (ExposeFunctionCategories = "Prefabricator", AllowPrivateAccess = "true"))
+	UPROPERTY(BlueprintReadOnly, Category = "Components", meta = (ExposeFunctionCategories = "Prefabricator", AllowPrivateAccess = "true"))
 	class UPrefabComponent* PrefabComponent;
 
 public:
@@ -26,19 +26,19 @@ public:
 #endif // WITH_EDITOR
 	/// End of AActor Interface 
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "Prefabricator")
 	void LoadPrefab();
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "Prefabricator")
 	void SavePrefab();
 
-	UFUNCTION(BlueprintCallable, BlueprintPure)
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Prefabricator")
 	bool IsPrefabOutdated();
 
-	UFUNCTION(BlueprintCallable, BlueprintPure)
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Prefabricator")
 	UPrefabricatorAsset* GetPrefabAsset();
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "Prefabricator")
 	void RandomizeSeed(const FRandomStream& InRandom, bool bRecursive = true);
 	void HandleBuildComplete();
 

--- a/Source/PrefabricatorRuntime/Public/Prefab/Random/PrefabRandomizerActor.h
+++ b/Source/PrefabricatorRuntime/Public/Prefab/Random/PrefabRandomizerActor.h
@@ -14,7 +14,7 @@ public:
 
 	virtual void BeginPlay() override;
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "Prefabricator")
 	void Randomize(int32 InSeed);
 
 #if WITH_EDITOR


### PR DESCRIPTION
All Function and properties when exposed to blueprint must have category explicitly specified.
It does not cause issues when plugin is inside Game/Plugins but when moved to Engine/Plugins it won't compile.