### PR TITLE
add visibility toggle for all prefab elements

### DIFF
--- a/Source/PrefabricatorRuntime/Private/Prefab/PrefabActor.cpp
+++ b/Source/PrefabricatorRuntime/Private/Prefab/PrefabActor.cpp
@@ -6,6 +6,7 @@
 #include "Asset/PrefabricatorAssetUserData.h"
 #include "Prefab/PrefabComponent.h"
 #include "Prefab/PrefabTools.h"
+#include "Utils/PrefabricatorFunctionLibrary.h"
 
 #include "Components/BillboardComponent.h"
 #include "Engine/PointLight.h"
@@ -97,6 +98,18 @@ FName APrefabActor::GetCustomIconName() const
 {
 	static const FName PrefabIconName("ClassIcon.PrefabActor");
 	return PrefabIconName;
+}
+
+void APrefabActor::SetIsTemporarilyHiddenInEditor(bool bIsHidden)
+{
+	Super::SetIsTemporarilyHiddenInEditor(bIsHidden);
+
+	TArray<AActor*> AttachedActors;
+	UPrefabricatorBlueprintLibrary::GetAllAttachedActors(this, AttachedActors);
+	for(AActor* AttachedActor : AttachedActors)
+	{
+		AttachedActor->SetIsTemporarilyHiddenInEditor(bHidden);
+	}
 }
 
 #endif // WITH_EDITOR

--- a/Source/PrefabricatorRuntime/Private/Prefab/PrefabActor.cpp
+++ b/Source/PrefabricatorRuntime/Private/Prefab/PrefabActor.cpp
@@ -108,7 +108,7 @@ void APrefabActor::SetIsTemporarilyHiddenInEditor(bool bIsHidden)
 	UPrefabricatorBlueprintLibrary::GetAllAttachedActors(this, AttachedActors);
 	for(AActor* AttachedActor : AttachedActors)
 	{
-		AttachedActor->SetIsTemporarilyHiddenInEditor(bHidden);
+		AttachedActor->SetIsTemporarilyHiddenInEditor(bIsHidden);
 	}
 }
 

--- a/Source/PrefabricatorRuntime/Public/Prefab/PrefabActor.h
+++ b/Source/PrefabricatorRuntime/Public/Prefab/PrefabActor.h
@@ -23,6 +23,7 @@ public:
 	virtual void PostEditChangeProperty(struct FPropertyChangedEvent& e) override;
 	virtual void PostDuplicate(EDuplicateMode::Type DuplicateMode) override;
 	virtual FName GetCustomIconName() const override;
+	virtual void SetIsTemporarilyHiddenInEditor( bool bIsHidden ) override;
 #endif // WITH_EDITOR
 	/// End of AActor Interface 
 


### PR DESCRIPTION
When toggling prefab visibility in the editor, allow all elements to inherit the change.