### PR TITLE
Add null check to fix crash when creating Prefab

### DIFF
--- a/Source/PrefabricatorEditor/Private/Utils/PrefabEditorTools.cpp
+++ b/Source/PrefabricatorEditor/Private/Utils/PrefabEditorTools.cpp
@@ -262,7 +262,9 @@ UThumbnailInfo* FPrefabEditorTools::CreateDefaultThumbInfo(UPrefabricatorAsset* 
 UPrefabricatorAsset* FPrefabEditorTools::CreatePrefabAsset()
 {
 	UPrefabricatorAsset* PrefabAsset = CreateAssetOnContentBrowser<UPrefabricatorAsset>("Prefab", true);
-	PrefabAsset->ThumbnailInfo = FPrefabEditorTools::CreateDefaultThumbInfo(PrefabAsset);
+	if (PrefabAsset) {
+		PrefabAsset->ThumbnailInfo = FPrefabEditorTools::CreateDefaultThumbInfo(PrefabAsset);
+	}
 	return PrefabAsset;
 }
 


### PR DESCRIPTION
If the user attempts to create a Prefab while an invalid content folder is selected in the Content Browser (e.g. "C++ Classes" folder) the Editor will crash.