### PR TITLE
Fix unneeded template saving (leads to crash)

### DIFF
--- a/Source/PrefabricatorRuntime/Private/Prefab/PrefabTools.cpp
+++ b/Source/PrefabricatorRuntime/Private/Prefab/PrefabTools.cpp
@@ -838,7 +838,7 @@ void FPrefabTools::LoadStateFromPrefabAsset(APrefabActor* PrefabActor, const FPr
 
 				ParentActors(PrefabActor, ChildActor);
 
-				if (Template == nullptr || bPrefabOutOfDate) {
+				if (Template == nullptr) {
 					// We couldn't use a template,  so load the prefab properties in
 					LoadActorState(ChildActor, ActorItemData, InSettings);
 


### PR DESCRIPTION
A template can be saved during actor spawning even if it is not necessary to save a template. This issue can result in a cycle of template saving, and will eventually result in the actor name character limit being reached and crashing the editor. I was able to reproduce this by trying to replace a large amount of actors (40) with prefabs.